### PR TITLE
Aggregated sum operation

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -6,7 +6,7 @@
 <script lang="ts">
 import { ComputedRef, defineComponent, inject, ref, watch } from 'vue';
 import { parseExpression } from './operations';
-import { checkFieldInTemplate, useDeepValues, useCollectionRelations } from './utils';
+import { useDeepValues, useCollectionRelations } from './utils';
 
 export default defineComponent({
 	props: {
@@ -43,6 +43,7 @@ export default defineComponent({
 			inject<ComputedRef<Record<string, any>>>('values')!,
 			relations,
 			props.collection,
+			props.field,
 			props.primaryKey,
 			props.template
 		);
@@ -52,15 +53,13 @@ export default defineComponent({
 				computedValue.value = compute();
 			}
 
-			watch(values, (val, oldVal) => {
-				if (shouldUpdate(val, oldVal)) {
-					if (props.displayOnly) {
-						computedValue.value = compute();
-					} else {
-						const newValue = compute();
-						if (newValue !== props.value) {
-							emit('input', newValue);
-						}
+			watch(values, () => {
+				if (props.displayOnly) {
+					computedValue.value = compute();
+				} else {
+					const newValue = compute();
+					if (newValue !== props.value) {
+						emit('input', newValue);
 					}
 				}
 			});
@@ -69,16 +68,6 @@ export default defineComponent({
 		return {
 			computedValue,
 		};
-
-		/** Simple check which fields are used */
-		function shouldUpdate(val: Record<string, any>, oldVal: Record<string, any>) {
-			for (const key of Object.keys(val)) {
-				if (key !== props.field && checkFieldInTemplate(props.template, key) && val[key] !== oldVal[key]) {
-					return true;
-				}
-			}
-			return false;
-		}
 
 		function compute() {
 			return props.template.replace(/{{.*?}}/g, (match) => {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -29,6 +29,11 @@ export function parseExpression(exp: string, values: Ref | undefined): any {
 				if (op === 'CURRENCY') {
 					return new Intl.NumberFormat().format(valueA);
 				}
+			} else if (op === 'ASUM') {
+				return (values.value[a] as unknown[]).reduce(
+					(acc, item) => acc + parseExpression(b, { value: item } as typeof values),
+					0
+				);
 			} else {
 				// binary operators
 				const valueB = parseExpression(b, values);

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -30,9 +30,12 @@ export function parseExpression(exp: string, values: Ref | undefined): any {
 					return new Intl.NumberFormat().format(valueA);
 				}
 			} else if (op === 'ASUM') {
-				return (values.value[a] as unknown[]).reduce(
-					(acc, item) => acc + parseExpression(b, { value: item } as typeof values),
-					0
+				// aggregated sum
+				return (
+					(values.value[a] as unknown[])?.reduce(
+						(acc, item) => acc + parseExpression(b, { value: item } as typeof values),
+						0
+					) ?? 0
 				);
 			} else {
 				// binary operators

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,82 @@
+import { watch, ref } from 'vue';
+import type { Ref } from 'vue';
+import { useApi, useStores } from '@directus/extensions-sdk';
+
+export function checkFieldInTemplate(template: string, field: string) {
+	const matches = template.match(/{{.*?}}/g);
+	return (matches || []).some((m) => m.includes(field));
+}
+
+export const useCollectionRelations = (collection: string): Ref<any[]> => {
+	const { useRelationsStore } = useStores();
+	const { getRelationsForCollection } = useRelationsStore();
+	return ref(getRelationsForCollection(collection));
+};
+
+interface IRelationUpdate<T = unknown> {
+	create: T[];
+	update: { owner: string; id: number | string }[];
+	delete: (number | string)[];
+}
+
+export const useDeepValues = (
+	values: Ref<Record<string, any>>,
+	relations: Ref<any[]>,
+	collection: string,
+	pk: string,
+	template: string
+) => {
+	const api = useApi();
+	const finalValues = ref<Record<string, any>>(values.value);
+	watch(values, async () => {
+		Object.keys(values.value).forEach(async (key) => {
+			const relation = relations.value.find((rel) => rel.meta?.one_field?.includes(key));
+
+			if (!relation || !checkFieldInTemplate(template, key)) {
+				return;
+			}
+
+			const fieldName = relation.meta.one_field;
+			const fieldChanges = values.value[fieldName] as IRelationUpdate;
+
+			let arrayOfIds: (string | number)[] = [];
+			let arrayOfData: unknown[] = [];
+			if (pk !== '+') {
+				const {
+					data: { data },
+				} = await api.get(`items/${collection}/${pk}`, {
+					params: {
+						fields: [fieldName],
+					},
+				});
+				arrayOfIds = arrayOfIds.concat(data.animaiszinhos);
+			}
+
+			if (fieldChanges.create) {
+				arrayOfData = arrayOfData.concat(fieldChanges.create);
+			}
+
+			if (fieldChanges.update) {
+				arrayOfIds = arrayOfIds.concat(fieldChanges.update.map(({ id }) => id));
+			}
+
+			if (fieldChanges.delete) {
+				arrayOfIds = arrayOfIds.filter((id) => !fieldChanges.delete.includes(id));
+			}
+
+			if (arrayOfIds.length) {
+				const {
+					data: { data },
+				} = await api.get(`items/${relation.collection}`, {
+					params: { filter: { id: { _in: arrayOfIds } } },
+				});
+
+				arrayOfData = arrayOfData.concat(data);
+			}
+
+			finalValues.value = { ...values.value, animaiszinhos: arrayOfData };
+		});
+	});
+
+	return finalValues;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,10 @@ export const useDeepValues = (
 			const fieldName = relation.meta.one_field;
 			const fieldChanges = values.value[fieldName] as IRelationUpdate;
 
+			if (!fieldChanges) {
+				return;
+			}
+
 			let arrayOfIds: (string | number)[] = [];
 			let arrayOfData: unknown[] = [];
 			if (pk !== '+') {
@@ -71,7 +75,11 @@ export const useDeepValues = (
 					params: { filter: { id: { _in: arrayOfIds } } },
 				});
 
-				arrayOfData = arrayOfData.concat(data);
+				// merging item updates
+				arrayOfData = data.map((item: any) => ({
+					...item,
+					...fieldChanges.update?.find(({ id }) => item.id === id),
+				}));
 			}
 
 			finalValues.value = { ...values.value, animaiszinhos: arrayOfData };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,7 +83,7 @@ export const useDeepValues = (
 				arrayOfData = arrayOfData.concat(fieldChanges.create);
 			}
 
-			finalValues.value = { ...values.value, [key]: arrayOfData };
+			finalValues.value = { ...finalValues.value, [key]: arrayOfData };
 		});
 	});
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,10 +56,6 @@ export const useDeepValues = (
 				arrayOfIds = arrayOfIds.concat(data.animaiszinhos);
 			}
 
-			if (fieldChanges.create) {
-				arrayOfData = arrayOfData.concat(fieldChanges.create);
-			}
-
 			if (fieldChanges.update) {
 				arrayOfIds = arrayOfIds.concat(fieldChanges.update.map(({ id }) => id));
 			}
@@ -80,6 +76,11 @@ export const useDeepValues = (
 					...item,
 					...fieldChanges.update?.find(({ id }) => item.id === id),
 				}));
+			}
+
+			// must concat after request, created items doenst have ids
+			if (fieldChanges.create) {
+				arrayOfData = arrayOfData.concat(fieldChanges.create);
 			}
 
 			finalValues.value = { ...values.value, animaiszinhos: arrayOfData };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,18 +29,20 @@ export const useDeepValues = (
 	const api = useApi();
 	const finalValues = ref<Record<string, any>>(values.value);
 	watch(values, async () => {
-		Object.keys(values.value).forEach(async (key) => {
+		const relationalData: Record<string, any> = {};
+
+		for (const key of Object.keys(values.value)) {
 			const relation = relations.value.find((rel) => rel.meta?.one_field === key);
 
 			if (!relation || !checkFieldInTemplate(template, key)) {
-				return;
+				continue;
 			}
 
 			const fieldName = relation.meta.one_field;
 			const fieldChanges = values.value[fieldName] as IRelationUpdate;
 
 			if (!fieldChanges) {
-				return;
+				continue;
 			}
 
 			let arrayOfIds: (string | number)[] = [];
@@ -83,8 +85,10 @@ export const useDeepValues = (
 				arrayOfData = arrayOfData.concat(fieldChanges.create);
 			}
 
-			finalValues.value = { ...finalValues.value, [key]: arrayOfData };
-		});
+			relationalData[key] = arrayOfData;
+		}
+
+		finalValues.value = { ...values.value, ...relationalData };
 	});
 
 	return finalValues;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export const useDeepValues = (
 	const finalValues = ref<Record<string, any>>(values.value);
 	watch(values, async () => {
 		Object.keys(values.value).forEach(async (key) => {
-			const relation = relations.value.find((rel) => rel.meta?.one_field?.includes(key));
+			const relation = relations.value.find((rel) => rel.meta?.one_field === key);
 
 			if (!relation || !checkFieldInTemplate(template, key)) {
 				return;
@@ -53,7 +53,7 @@ export const useDeepValues = (
 						fields: [fieldName],
 					},
 				});
-				arrayOfIds = arrayOfIds.concat(data.animaiszinhos);
+				arrayOfIds = arrayOfIds.concat(data[key]);
 			}
 
 			if (fieldChanges.update) {
@@ -83,7 +83,7 @@ export const useDeepValues = (
 				arrayOfData = arrayOfData.concat(fieldChanges.create);
 			}
 
-			finalValues.value = { ...values.value, animaiszinhos: arrayOfData };
+			finalValues.value = { ...values.value, [key]: arrayOfData };
 		});
 	});
 


### PR DESCRIPTION
This PR allow us to make aggregated sum using item relational fields.
Added a new operation called `ASUM`. The first parameter receives the name of the relational field and the second can either be the child field to be summed or a operation using the child fields.
For example:

If I wish to calculate the sum of my horses ages:
```{{ ASUM(horses, age) }}```

Or calculate the total price of a product list on my cart:
```{{ ASUM(products, MULTIPLY(quantity, price)) }}```

Closes #1 