### PR TITLE
fix: handle null emits

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -70,10 +70,16 @@ export default defineComponent({
 		};
 
 		function compute() {
-			return props.template.replace(/{{.*?}}/g, (match) => {
+			const computedValue = props.template.replace(/{{.*?}}/g, (match) => {
 				const expression = match.slice(2, -2).trim();
 				return parseExpression(expression, values.value);
 			});
+
+			if (!computedValue) {
+				return null;
+			}
+
+			return computedValue;
 		}
 	},
 });

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -8,7 +8,21 @@ export function parseExpression(exp: string, values: Record<string, any>): any {
 		const opMatch = parseOp(exp);
 		if (opMatch) {
 			const { op, a, b } = opMatch;
+
+			if (op === 'ASUM') {
+				// aggregated sum
+				return (
+					(values[a] as unknown[])?.reduce(
+						(acc, item) => acc + parseExpression(b!, item as typeof values),
+						0
+					) ?? 0
+				);
+			}
+
 			const valueA = parseExpression(a, values);
+			if (!valueA) {
+				return '';
+			}
 
 			// unary operators
 			if (b === null) {
@@ -85,14 +99,6 @@ export function parseExpression(exp: string, values: Record<string, any>): any {
 					}
 					return 0;
 				}
-			} else if (op === 'ASUM') {
-				// aggregated sum
-				return (
-					(values[a] as unknown[])?.reduce(
-						(acc, item) => acc + parseExpression(b, item as typeof values),
-						0
-					) ?? 0
-				);
 			} else {
 				// binary operators
 				const valueB = parseExpression(b, values);


### PR DESCRIPTION
This PR verifies when the parsed expression returns a empty value and properly emits `null`, so Directus can take care of the empty field.

Closes #7