### PR TITLE
feat: adds new Read Only option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,15 +20,19 @@ export default defineInterface({
 			},
 		},
 		{
-			field: 'displayOnly',
-			name: 'Display Only',
-			type: 'boolean',
-			schema: {
-				default_value: false,
-			},
+			field: 'mode',
+			name: 'Field Mode',
+			type: 'string',
 			meta: {
-				interface: 'boolean',
 				width: 'half',
+				interface: 'select-dropdown',
+				options: {
+					allowNone: true,
+					choices: [
+						{ text: 'Display Only', value: 'displayonly' },
+						{ text: 'Read Only', value: 'readonly' },
+					],
+				},
 			},
 		},
 	],

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="displayOnly">{{ computedValue }}</div>
+	<div v-if="mode">{{ computedValue }}</div>
 	<v-input v-else v-model="value" />
 </template>
 
@@ -30,14 +30,14 @@ export default defineComponent({
 			type: String,
 			default: '',
 		},
-		displayOnly: {
-			type: Boolean,
-			default: false,
+		mode: {
+			type: String,
+			default: null,
 		},
 	},
 	emits: ['input'],
 	setup(props, { emit }) {
-		const computedValue = ref('');
+		const computedValue = ref(props.value);
 		const relations = useCollectionRelations(props.collection);
 		const values = useDeepValues(
 			inject<ComputedRef<Record<string, any>>>('values')!,
@@ -49,18 +49,15 @@ export default defineComponent({
 		);
 
 		if (values) {
-			if (props.displayOnly) {
-				computedValue.value = compute();
-			}
-
 			watch(values, () => {
-				if (props.displayOnly) {
-					computedValue.value = compute();
-				} else {
-					const newValue = compute();
-					if (newValue !== props.value) {
-						emit('input', newValue);
-					}
+				const newValue = compute();
+				computedValue.value = newValue;
+
+				if (props.mode === 'displayonly') {
+					return;
+				}
+				if (newValue !== props.value) {
+					emit('input', newValue);
 				}
 			});
 		}


### PR DESCRIPTION
Now we have two options for interface: `Display Only` and `Read Only`. The display only option doens't emit events for field changes. Example:
![ezgif-1-652c843dc4](https://user-images.githubusercontent.com/9392803/198069434-f63d6f81-0d85-4ee7-ae5d-c80f451e23e2.gif)


Closes #6 