### PR TITLE
feat: add CATCH op

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Operator | Description
 Operator | Description
 --- | ---
 `RANGE(start, end, step)` | create an array of numbers from `start` to `end` with `step` increment/decrement. Example: `RANGE(1, 10, 2)` returns `[1, 3, 5, 7, 9]`.
+`CATCH(exp, fallback)` | return `exp` when no errors, otherwise `fallback` 
 
 ## Dynamic Variables
 

--- a/src/operations.test.ts
+++ b/src/operations.test.ts
@@ -609,6 +609,11 @@ describe('Test parseExpression', () => {
       expect(parseExpression('RANGE(a, b, c)', { a: 1, b: 6, c: 2 })).toEqual([1, 3, 5]);
       expect(parseExpression('RANGE(a, b, c)', { a: 5, b: 0, c: -2 })).toEqual([5, 3, 1]);
     });
+
+		test('CATCH op', () => {
+			expect(parseExpression('CATCH(a.b, c)', { a: { b: 'ok' }, c: 'fallback' })).toEqual('ok');
+			expect(parseExpression('CATCH(a.b, c)', { a: null, c: 'fallback' })).toEqual('fallback');
+		});
   });
 
   describe('Nested expressions', () => {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -290,6 +290,33 @@ function _parseExpression(
 					});
 				}
 
+				if (op === "CATCH") {
+					try {
+						return parseExpression(
+							args[0],
+							values,
+							defaultValues,
+							debug,
+						);
+					} catch (e: unknown) {
+						if (debug) {
+							const errorMessage = e instanceof Error
+								? e.message
+								: String(e);
+							console.log(
+								`${args[0]} =`,
+								`FAIL: ${errorMessage}`,
+							);
+						}
+						return parseExpression(
+							args[1],
+							values,
+							defaultValues,
+							debug,
+						);
+					}
+				}
+
 				// binary operators
 				const valueA = parseExpression(args[0], values, defaultValues, debug);
 				const valueB = parseExpression(args[1], values, defaultValues, debug);


### PR DESCRIPTION
This let us handle cases where we have model with an optional relation.

Example with a recursive model
```
page

- slug (Type: String)
- parent (Type: M2O)
```

This expression doesn't work when parent is not set
`{{ IF(NOT_NULL(parent), parent.slug, "") }}`

With the CATCH it works and the expression is simpler
`{{ CATCH(parent.slug, "") }}`